### PR TITLE
🔍️ Add OGP metadata

### DIFF
--- a/src/botdata/templates/botdata/channel.jinja2
+++ b/src/botdata/templates/botdata/channel.jinja2
@@ -1,5 +1,14 @@
 {% extends "base.jinja2" %}
 
+{% block ogp %}
+    <meta property="og:title" content="DuckHunt"/>
+    <meta property="og:type" content="channel"/>
+    <meta property="og:url" content="{{ canonical_domain_uri }}{{ request.get_full_path() }}"/>
+    <meta property="og:site_name" content="DuckHunt Discord V4"/>
+    <meta property="og:description"
+          content="DuckHunt top scores for {{ paginator.count }} players on {{ channel.name }}."/>
+{% endblock %}
+
 {% block metadesc %}
     <meta name="description"
           content="{{ _('DuckHunt top scores for %(players)s players on #%(channel_name)s.', players=paginator.count, channel_name=channel.name) }}">

--- a/src/botdata/templates/botdata/channel_settings.jinja2
+++ b/src/botdata/templates/botdata/channel_settings.jinja2
@@ -6,7 +6,7 @@
     <meta property="og:url" content="{{ canonical_domain_uri }}{{ request.get_full_path() }}"/>
     <meta property="og:site_name" content="DuckHunt Discord V4"/>
     <meta property="og:description"
-          content="{% trans channel_name=channel.name %}DuckHunt settings for #{{ channel_name }}.{% endtrans %}"/>
+          content="DuckHunt settings for #{{ channel_name }}."/>
 {% endblock %}
 
 {% block metadesc %}

--- a/src/botdata/templates/botdata/channel_settings.jinja2
+++ b/src/botdata/templates/botdata/channel_settings.jinja2
@@ -1,5 +1,14 @@
 {% extends "base.jinja2" %}
 
+{% block ogp %}
+    <meta property="og:title" content="DuckHunt"/>
+    <meta property="og:type" content="guild settings"/>
+    <meta property="og:url" content="{{ canonical_domain_uri }}{{ request.get_full_path() }}"/>
+    <meta property="og:site_name" content="DuckHunt Discord V4"/>
+    <meta property="og:description"
+          content="{% trans channel_name=channel.name %}DuckHunt settings for #{{ channel_name }}.{% endtrans %}"/>
+{% endblock %}
+
 {% block metadesc %}
     <meta name="description"
           content="{% trans channel_name=channel.name %}DuckHunt settings for #{{ channel_name }}.{% endtrans %}">

--- a/src/botdata/templates/botdata/guild.jinja2
+++ b/src/botdata/templates/botdata/guild.jinja2
@@ -1,5 +1,14 @@
 {% extends "base.jinja2" %}
 
+{% block ogp %}
+    <meta property="og:title" content="DuckHunt"/>
+    <meta property="og:type" content="guild"/>
+    <meta property="og:url" content="{{ canonical_domain_uri }}{{ request.get_full_path() }}"/>
+    <meta property="og:site_name" content="DuckHunt Discord V4"/>
+    <meta property="og:description"
+          content="Join the {{ guild.name }} server on Discord and play with DuckHunt."/>
+{% endblock %}
+
 {% block metadesc %}
     <meta name="description" content="{{ _("Join the %(guild_name)s server on Discord and play with DuckHunt.", guild_name=guild.name) }}">
 {% endblock %}

--- a/src/botdata/templates/botdata/guild_landmines.jinja2
+++ b/src/botdata/templates/botdata/guild_landmines.jinja2
@@ -1,5 +1,14 @@
 {% extends "base.jinja2" %}
 
+{% block ogp %}
+    <meta property="og:title" content="DuckHunt"/>
+    <meta property="og:type" content="landmines"/>
+    <meta property="og:url" content="{{ canonical_domain_uri }}{{ request.get_full_path() }}"/>
+    <meta property="og:site_name" content="DuckHunt Discord V4"/>
+    <meta property="og:description"
+          content="Landmines statistics on {{ guild.name }}"/>
+{% endblock %}
+
 {% block metadesc %}
     <meta name="description"
           content="{{ _('DuckHunt V4 - Landmines statistics on %(guild_name)s', guild_name=guild.name) }}">

--- a/src/botdata/templates/botdata/guilds.jinja2
+++ b/src/botdata/templates/botdata/guilds.jinja2
@@ -1,5 +1,14 @@
 {% extends "base.jinja2" %}
 
+{% block ogp %}
+    <meta property="og:title" content="DuckHunt"/>
+    <meta property="og:type" content="guilds"/>
+    <meta property="og:url" content="{{ canonical_domain_uri }}{{ request.get_full_path() }}"/>
+    <meta property="og:site_name" content="DuckHunt Discord V4"/>
+    <meta property="og:description"
+          content="All the DuckHunt servers{% if language %} in {{ language }}{% endif %}."/>
+{% endblock %}
+
 {% block metadesc %}
     <meta name="description" content="All the DuckHunt servers{% if language %} in {{ language }}{% endif %}.">
 {% endblock %}


### PR DESCRIPTION
This PR will add [OGP](https://ogp.me/) metadata on pages under `/data` for SEO improvement. 